### PR TITLE
Fix numpy mailing list links

### DIFF
--- a/projects/NumPy.md
+++ b/projects/NumPy.md
@@ -37,8 +37,7 @@ BSD-3-Clause: http://www.numpy.org/license.html#license
 ## Contact
 
 ### Discussion Forums
-- Discussion: https://mail.scipy.org/mailman/listinfo/numpy-discussion
-- Numpy-svn: https://mail.scipy.org/mailman/listinfo/numpy-svn
+- Discussion: https://mail.python.org/pipermail/numpy-discussion/
 
 ### Events
 ?


### PR DESCRIPTION
Moved from mail.scipy.org to mail.python.org a while ago, and numpy-svn appears to have been dead for over a year (plus it was just the github commit log).