### PR TITLE
Add Markdown translation of NumFOCUS CoC

### DIFF
--- a/manual/numfocus-coc.md
+++ b/manual/numfocus-coc.md
@@ -232,6 +232,4 @@ We aim to respond **within one week** to the original reporter with either a res
 
 This code of conduct has been adapted from numerous sources, including the [*Geek Feminism wiki, created by the Ada Initiative and other volunteers, which is under a Creative Commons Zero license*](http://geekfeminism.wikia.com/wiki/Conference_anti-harassment/Policy), the [*Contributor Covenant version 1.2.0*](http://contributor-covenant.org/version/1/2/0/), the [*Bokeh Code of Conduct*](https://github.com/bokeh/bokeh/blob/master/CODE_OF_CONDUCT.md), the [*SciPy Code of Conduct*](https://github.com/jupyter/governance/blob/master/conduct/enforcement.md), the [*Carpentries Code of Conduct*](https://docs.carpentries.org/topic_folders/policies/code-of-conduct.html#enforcement-manual), and the [*NIPS Code of Conduct*](https://nips.cc/public/CodeOfConduct).
 
-**NumFOCUS Code of Conduct is licensed under a **[***Creative Commons
-Attribution 3.0 Unported
-License.***](https://creativecommons.org/licenses/by/3.0/)
+**NumFOCUS Code of Conduct is licensed under the [Creative Commons Attribution 3.0 Unported License](https://creativecommons.org/licenses/by/3.0/).**

--- a/manual/numfocus-coc.md
+++ b/manual/numfocus-coc.md
@@ -35,7 +35,7 @@ All communication should be appropriate for a professional audience including pe
 
 Thank you for helping make this a welcoming, friendly community for all.
 
-**CODE OF CONDUCT REPORTING FORM:** [*https://numfocus.typeform.com/to/ynjGdT*](https://numfocus.typeform.com/to/ynjGdT)
+**CODE OF CONDUCT REPORTING FORM:** [*https://URL/to/your/CoC/reporting/form*](https://URL/to/your/CoC/reporting/form)
 
 ## The Longer Version
 
@@ -115,12 +115,13 @@ Take care of each other. Alert [PROJECT] if you notice a dangerous situation, so
 
 [PROJECT] is committed to promptly addressing any reported issues. If you have experienced or witnessed behavior that violates the [PROJECT] Code of Conduct, please complete the form below to make a report.
 
-**REPORTING FORM:** [*https://numfocus.typeform.com/to/ynjGdT*](https://numfocus.typeform.com/to/ynjGdT)
+**REPORTING FORM:** [*https://URL/to/your/CoC/reporting/form*](https://URL/to/your/CoC/reporting/form)
 
 Reports are sent to the [PROJECT] Code of Conduct Enforcement Team (see below).
 
-You can view the Privacy Policy and Terms of Service for TypeForm at [*https://terms.typeform.com/to/fJAmVc*](https://terms.typeform.com/to/fJAmVc). The NumFOCUS Privacy Policy is at [*https://www.numfocus.org/privacy-policy*](https://www.numfocus.org/privacy-policy)
-[MAY NEED TO INSERT LANGUAGE HERE RE: THE PROJECT'S PRIVACY POLICY]
+<!-- If you are using TypeForm, leave the following text in place -->
+
+You can view the Privacy Policy and Terms of Service for TypeForm at [*https://terms.typeform.com/to/fJAmVc*](https://terms.typeform.com/to/fJAmVc).
 
 #### Person(s) Responsible for Resolving Complaints
 
@@ -179,7 +180,7 @@ What happens after a report is filed?
 
 [PROJECT] and/or our event staff will attempt to ensure your safety and help with any immediate needs, particularly at an in-person event.  [PROJECT] will make every effort to **acknowledge receipt within 24 hours** (and we'll aim for much more quickly than that).  
 
-[PROJECT SHOULD REVIEW THE RESPONSE SCHEDULE LISTED ABOVE AND BELOW, AND DETERMINE WHETHER IT IS REALISTIC FOR THE PROJECT.]
+<!-- PROJECT SHOULD REVIEW THE RESPONSE SCHEDULE LISTED ABOVE AND BELOW, AND DETERMINE WHETHER IT IS REALISTIC FOR THE PROJECT. -->
 
 #### Reviewing the Report
 

--- a/manual/numfocus-coc.md
+++ b/manual/numfocus-coc.md
@@ -149,40 +149,26 @@ What happens after a report is filed?
 
 #### Acknowledgment and Responding to Immediate Needs
 
-NumFOCUS and/or our event staff will attempt to ensure your safety and
-help with any immediate needs, particularly at an in-person event.
-NumFOCUS will make every effort to **acknowledge receipt within 24
-hours** (and we'll aim for much more quickly than that).
+NumFOCUS and/or our event staff will attempt to ensure your safety and help with any immediate needs, particularly at an in-person event.  NumFOCUS will make every effort to **acknowledge receipt within 24 hours** (and we'll aim for much more quickly than that).
 
 #### Reviewing the Report
 
-NumFOCUS will make all efforts to **review the incident within three
-days** and determine:
+NumFOCUS will make all efforts to **review the incident within three days** and determine:
 
--   Whether this is an ongoing situation, or if there is a threat to
-    anyone's physical safety
--   What happened
--   Whether this event constitutes a code of conduct violation
--   Who the bad actor was, if any
+- Whether this is an ongoing situation, or if there is a threat to anyone's physical safety
+- What happened
+- Whether this event constitutes a code of conduct violation
+- Who the bad actor was, if any
 
-If the incident took place at an event or meetup or within the community
-channels of a NumFOCUS project, the NumFOCUS Code of Conduct Enforcement
-Team will reach out to the relevant organizers/community
-managers/project leaders as necessary to follow up on the incident.
+If the incident took place at an event or meetup or within the community channels of a NumFOCUS project, the NumFOCUS Code of Conduct Enforcement Team will reach out to the relevant organizers/community managers/project leaders as necessary to follow up on the incident.
 
 #### Contacting the Person Reported
 
-After NumFOCUS has had time to review and discuss the report, someone
-will attempt to contact the person who is the subject of the report to
-inform them of what has been reported about them. We will then ask that
-person for their account of what happened.
+After NumFOCUS has had time to review and discuss the report, someone will attempt to contact the person who is the subject of the report to inform them of what has been reported about them. We will then ask that person for their account of what happened.
 
 #### Response and Potential Consequences
 
-Once NumFOCUS has completed our investigation of the report, we will
-make a decision as to how to respond. The person making a report will
-not normally be consulted as to the proposed resolution of the issue,
-except insofar as we need to understand how to help them feel safe.
+Once NumFOCUS has completed our investigation of the report, we will make a decision as to how to respond. The person making a report will not normally be consulted as to the proposed resolution of the issue, except insofar as we need to understand how to help them feel safe.
 
 Potential consequences for violating the NumFOCUS code of conduct include:
 

--- a/manual/numfocus-coc.md
+++ b/manual/numfocus-coc.md
@@ -1,4 +1,4 @@
-# NumFOCUS Code of Conduct
+# [PROJECT] Code of Conduct
 
 ## The Short Version
 

--- a/manual/numfocus-coc.md
+++ b/manual/numfocus-coc.md
@@ -1,0 +1,251 @@
+# NumFOCUS Code of Conduct
+
+## The Short Version
+
+Be kind to others. Do not insult or put down others. Behave professionally. Remember that harassment and sexist, racist, or exclusionary jokes are not appropriate for NumFOCUS.
+
+All communication should be appropriate for a professional audience including people of many different backgrounds. Sexual language and imagery is not appropriate.
+
+NumFOCUS is dedicated to providing a harassment-free community for everyone, regardless of gender, sexual orientation, gender identity, and expression, disability, physical appearance, body size, race, or religion. We do not tolerate harassment of community members in any form.
+
+Thank you for helping make this a welcoming, friendly community for all.
+
+**CODE OF CONDUCT REPORTING FORM:** [*https://numfocus.typeform.com/to/ynjGdT*](https://numfocus.typeform.com/to/ynjGdT)
+
+## The Longer Version
+
+### NumFOCUS Diversity Statement
+
+NumFOCUS welcomes and encourages participation in our community by people of all backgrounds and identities. We are committed to promoting and sustaining a culture that values mutual respect, tolerance, and learning, and we work together as a community to help each other live out these values.
+
+We have created this diversity statement because we believe that a diverse community is stronger, more vibrant, and produces better software and better science. A diverse community where people treat each other with respect has more potential contributors, more sources for ideas, and fewer shared assumptions that might hinder development or research.
+
+Although we have phrased the formal diversity statement generically to make it all-inclusive, we recognize that there are specific identities that are impacted by systemic discrimination and marginalization. We welcome all people to participate in the NumFOCUS community regardless of their identity or background.
+
+### NumFOCUS Code of Conduct: Introduction & Scope
+
+This code of conduct should be honored by everyone who participates in the NumFOCUS community. It should be honored in any NumFOCUS-related activities, by anyone claiming affiliation with NumFOCUS, and especially when someone is representing NumFOCUS in any role (including as an event volunteer or speaker).
+
+This code of conduct applies to all spaces managed by NumFOCUS, including all public and private mailing lists, issue trackers, wikis, forums, and any other communication channel used by our community. The code of conduct equally applies at NumFOCUS events and governs standards of behavior for attendees, speakers, volunteers, booth staff, and event sponsors.
+
+This code is not exhaustive or complete. It serves to distill our understanding of a collaborative, inclusive community culture. Please try to follow this code in spirit as much as in letter, to create a friendly and productive environment that enriches the NumFOCUS community.
+
+We require all NumFOCUS sponsored and affiliated projects to adopt a code of conduct for their project that encourages a productive, respectful environment for all open source contributors and community members. The NumFOCUS Code of Conduct follows below.
+
+### Standards for Behavior
+
+NumFOCUS is a worldwide community. All communication should be appropriate for a professional audience including people of many different backgrounds.
+
+**Please always be kind and courteous. There's never a need to be mean or rude or disrespectful.** Thank you for helping make this a welcoming, friendly community for all.
+
+We strive to:
+
+**Be empathetic, welcoming, friendly, and patient.** We remember that every NumFOCUS project and program is crafted by human beings who deserve to be treated with kindness and empathy. We work together to resolve conflict and assume good intentions. We may all experience some frustration from time to time, but we do not allow frustration to turn into a personal attack. A community where people feel uncomfortable or threatened is not a productive one.
+
+**Be collaborative.** Our work depends on the participation of many people, and in turn others depend on our work. Open source communities depend on effective and friendly collaboration to achieve their goals.
+
+**Be inquisitive.** Nobody knows everything! Asking questions early avoids many problems later, so we encourage questions, although we may direct them to the appropriate forum. We will try hard to be responsive and helpful.
+
+**Be careful in the words that we choose.** We are careful and respectful in our communication and we take responsibility for our own speech. Be kind to others. Do not insult or put down other members of the community.
+
+#### Unacceptable Behavior
+
+We are committed to making participation in this community a harassment-free experience.
+
+We will not accept harassment or other exclusionary behaviours, such as:
+
+- The use of sexualized language or imagery
+- Excessive profanity (please avoid curse words; people differ greatly in their sensitivity to swearing)
+- Posting sexually explicit or violent material
+- Violent or intimidating threats or language directed against another person
+- Inappropriate physical contact and/or unwelcome sexual attention or sexual comments
+- Sexist, racist, or otherwise discriminatory jokes and language
+- Trolling or insulting and derogatory comments
+- Written or verbal comments which have the effect of excluding people on the basis of membership in a specific group, including level of experience, gender, gender identity and expression, sexual orientation, disability, neurotype, personal appearance, body size, race, ethnicity, age, religion, or nationality
+- Public or private harassment
+- Sharing private content, such as emails sent privately or non-publicly, or direct message history, without the sender's consent
+- Continuing to initiate interaction (such as photography, recording, messaging, or conversation) with someone after being asked to stop
+- Sustained disruption of talks, events, or communications, such as heckling of a speaker
+- Publishing (or threatening to post) other people's personally identifying information ("doxing"), such as physical or electronic addresses, without explicit permission
+- Other unethical or unprofessional conduct
+- Advocating for, or encouraging, any of the above behaviors
+
+### Reporting Guidelines
+
+If you believe someone is violating the code of conduct, please report this in a timely manner. Code of conduct violations reduce the value of the community for everyone. The team at NumFOCUS takes reports of misconduct very seriously and is committed to preserving and maintaining the welcoming nature of our community.
+
+**All reports will be kept confidential.**
+
+In some cases we may determine that a public statement will need to be made. If that's the case, the identities of all involved parties and reporters will remain confidential unless those individuals instruct us otherwise.
+
+All complaints will be reviewed and investigated and will result in a response that is deemed necessary and appropriate to the circumstances.  The NumFOCUS team commits to maintaining confidentiality with regard to the reporter of an incident.
+
+For possibly unintentional breaches of the code of conduct, you may want to respond to the person and point out this code of conduct (either in public or in private, whatever is most appropriate). If you would prefer not to do that, please report the issue to NumFOCUS directly, or ask NumFOCUS Executive Director Leah Silen for advice in confidence (leah@numfocus.org). Complete contact information is below, under "How to Submit a Report."
+
+Take care of each other. Alert NumFOCUS if you notice a dangerous situation, someone in distress, or violations of this code of conduct, even if they seem inconsequential.
+
+#### How to Submit a Report
+
+**If you feel your safety is in jeopardy or the situation is an emergency, we urge you to contact local law enforcement before making a report to NumFOCUS.** (In the U.S., dial 911.)
+
+NumFOCUS is committed to promptly addressing any reported issues. If you have experienced or witnessed behavior that violates the NumFOCUS Code of Conduct, please complete the form below to make a report.
+
+**REPORTING FORM:** [*https://numfocus.typeform.com/to/ynjGdT*](https://numfocus.typeform.com/to/ynjGdT)
+
+Reports are sent to the NumFOCUS Code of Conduct Enforcement Team (see below).
+
+You can view the Privacy Policy and Terms of Service for TypeForm at [*https://terms.typeform.com/to/fJAmVc*](https://terms.typeform.com/to/fJAmVc). The NumFOCUS Privacy Policy is at [*https://www.numfocus.org/privacy-policy*](https://www.numfocus.org/privacy-policy)
+
+#### Person(s) Responsible for Resolving Complaints
+
+All reports of breaches of the code of conduct will be investigated and handled by the **NumFOCUS Code of Conduct Enforcement Team**.
+
+The current NumFOCUS Code of Conduct Enforcement Team consists of:
+
+-   Leah Silen, Executive Director
+
+    -   [*leah@numfocus.org*](mailto:leah@numfocus.org)
+
+    -   +1 (512) 831-2870 or +1 (972) 896-3688
+
+-   Andy Terrel, President
+
+    -   [*andy@numfocus.org*](mailto:andy@numfocus.org)
+
+-   Gina Helfrich, Communications Director and Program Manager for Diversity & Inclusion
+
+    -   [*gina@numfocus.org*](mailto:gina@numfocus.org)
+
+You can reach the entire Code of Conduct Enforcement Team by emailing [***conduct@numfocus.org***](mailto:conduct@numfocus.org).
+
+If an incident takes place at an event or meetup or within the community channels of a NumFOCUS project, the NumFOCUS Code of Conduct Enforcement Team will reach out to the relevant organizers/community managers/project leaders as necessary to follow up on the incident.
+
+#### Conflicts of Interest
+
+In the event of any conflict of interest, the team member will immediately notify the Board and recuse themselves if necessary.
+
+If you are concerned about making a report that will be read by any of the above individuals, please reach out to one of the members of the [*NumFOCUS Board*](https://www.numfocus.org/people#people-directors).
+
+#### What to Include in a Report
+
+Our ability to address any code of conduct breaches in a timely and effective manner is impacted by the amount of information you can provide, so, **our reporting form asks you to include as much of the following information as you can**:
+
+- **Your contact info** (so we can get in touch with you if we need to follow up). This will be kept confidential. If you wish to remain anonymous, your information will not be shared beyond the person receiving the initial report.
+- The **approximate time and location of the incident** (please be as specific as possible)
+- **Identifying information** (e.g. name, nickname, screen name, physical description) of the individual whose behavior is being reported
+- **Description of the behavior** (if reporting harassing language, please be specific about the words used), **your account of what happened**, and any available **supporting records** (e.g. email, GitHub issue, screenshots, etc.)
+- **Description of the circumstances/context** surrounding the incident
+- Let us know **if the incident is ongoing**, and/or if this is part of an ongoing pattern of behavior
+- Names and contact info, if possible, of **anyone else who witnessed** or was involved in this incident. (Did anyone else observe the incident?)
+- **Any other relevant information** you believe we should have
+
+Event staff/meetup organizers will attempt to gather and write down the above information from anyone making a verbal report in-person at an event. Recording the details in writing is exceedingly important in order for us to effectively respond to reports. If event staff/meetup organizers write down a report taken verbally, then the person making the report will be asked to review the written report for accuracy.
+
+**If urgent action is needed regarding an incident at an in-person event, we strongly encourage you to reach out to the local event staff/meetup organizers for immediate assistance.**
+
+### Enforcement: What Happens After a Report is Filed?
+
+What happens after a report is filed?
+
+#### Acknowledgment and Responding to Immediate Needs
+
+NumFOCUS and/or our event staff will attempt to ensure your safety and
+help with any immediate needs, particularly at an in-person event.
+NumFOCUS will make every effort to **acknowledge receipt within 24
+hours** (and we'll aim for much more quickly than that).
+
+#### Reviewing the Report
+
+NumFOCUS will make all efforts to **review the incident within three
+days** and determine:
+
+-   Whether this is an ongoing situation, or if there is a threat to
+    anyone's physical safety
+-   What happened
+-   Whether this event constitutes a code of conduct violation
+-   Who the bad actor was, if any
+
+If the incident took place at an event or meetup or within the community
+channels of a NumFOCUS project, the NumFOCUS Code of Conduct Enforcement
+Team will reach out to the relevant organizers/community
+managers/project leaders as necessary to follow up on the incident.
+
+#### Contacting the Person Reported
+
+After NumFOCUS has had time to review and discuss the report, someone
+will attempt to contact the person who is the subject of the report to
+inform them of what has been reported about them. We will then ask that
+person for their account of what happened.
+
+#### Response and Potential Consequences
+
+Once NumFOCUS has completed our investigation of the report, we will
+make a decision as to how to respond. The person making a report will
+not normally be consulted as to the proposed resolution of the issue,
+except insofar as we need to understand how to help them feel safe.
+
+Potential consequences for violating the NumFOCUS code of conduct include:
+
+- Nothing (if we determine that no violation occurred)
+- Private feedback or reprimand from NumFOCUS to the individual(s) involved
+- Warning the person to cease their behavior and that any further reports will result in sanctions
+- A public announcement that an incident occurred
+- Mediation (only if both reporter and reportee agree)
+- An imposed vacation (e.g. asking someone to "take a week off" from a mailing list)
+- A permanent or temporary ban from some or all NumFOCUS spaces (mailing lists, GitHub repos, in-person events, etc.)
+- Assistance to the complainant with a report to other bodies, for example, institutional offices or appropriate law enforcement agencies
+- Removing a person from NumFOCUS membership or other formal affiliation
+- Publishing an account of the harassment and calling for the resignation of the alleged harasser from their responsibilities (usually pursued by people without formal authority: may be called for if the person is the event leader, or refuses to stand aside from the conflict of interest, or similar)
+- Any other response that NumFOCUS deems necessary and appropriate to the situation
+
+At NumFOCUS events, if a participant engages in behavior that violates this code of conduct, the conference organizers and staff may take any action they deem appropriate.
+
+Potential consequences for violating the NumFOCUS Code of Conduct at an in-person event include:
+
+- Warning the person to cease their behavior and that any further reports will result in sanctions
+- Requiring that the person avoid any interaction with, and physical proximity to, the person they are harassing for the remainder of the event
+- Ending a talk that violates the policy early
+- Not publishing the video or slides of a talk that violated the policy
+- Not allowing a speaker who violated the policy to give (further) talks at the event now or in the future
+- Immediately ending any event volunteer responsibilities and privileges the reported person holds
+- Requiring that the person not volunteer for future events NumFOCUS runs (either indefinitely or for a certain time period)
+- Expelling the person from the event without a refund
+- Requiring that the person immediately leave the event and not return
+- Banning the person from future events (either indefinitely or for a certain time period)
+- Any other response that NumFOCUS deems necessary and appropriate to the situation
+
+No one espousing views or values contrary to the standards of our code of conduct will be permitted to hold any position representing NumFOCUS, including volunteer positions. NumFOCUS has the right and responsibility to remove, edit, or reject comments, commits, code, wiki edits, issues, and other contributions that are not aligned with this code of conduct.
+
+We aim to **respond within one week** to the original reporter with either a resolution or an explanation of why the situation is not yet resolved.
+
+We will write to the person who is the subject of the report to let them know what actions will be taken as a result of the report, if any.
+
+Our policy is to make sure that everyone aware of the initial incident is also made aware that official action has been taken, while still respecting the privacy of individuals. NumFOCUS may choose to make a public report of the incident, while maintaining the anonymity of those involved.
+
+#### Appealing a Decision
+
+To appeal a decision of NumFOCUS, contact Leah Silen via email at
+[*leah@numfocus.org*](mailto:leah@numfocus.org) with your appeal and
+the Board will review the case.
+
+### Timeline Summary:
+
+#### Confirming Receipt
+
+NumFOCUS will make every effort to acknowledge receipt of a report **within 24 hours** (and we'll aim for much more quickly than that).
+
+#### Reviewing the Report
+
+NumFOCUS will make all efforts to review the incident **within three days**.
+
+#### Consequences & Resolution
+
+We aim to respond **within one week** to the original reporter with either a resolution or an explanation of why the situation is not yet resolved.
+
+## License
+
+This code of conduct has been adapted from numerous sources, including the [*Geek Feminism wiki, created by the Ada Initiative and other volunteers, which is under a Creative Commons Zero license*](http://geekfeminism.wikia.com/wiki/Conference_anti-harassment/Policy), the [*Contributor Covenant version 1.2.0*](http://contributor-covenant.org/version/1/2/0/), the [*Bokeh Code of Conduct*](https://github.com/bokeh/bokeh/blob/master/CODE_OF_CONDUCT.md), the [*SciPy Code of Conduct*](https://github.com/jupyter/governance/blob/master/conduct/enforcement.md), the [*Carpentries Code of Conduct*](https://docs.carpentries.org/topic_folders/policies/code-of-conduct.html#enforcement-manual), and the [*NIPS Code of Conduct*](https://nips.cc/public/CodeOfConduct).
+
+**NumFOCUS Code of Conduct is licensed under a **[***Creative Commons
+Attribution 3.0 Unported
+License.***](https://creativecommons.org/licenses/by/3.0/)

--- a/manual/numfocus-coc.md
+++ b/manual/numfocus-coc.md
@@ -2,11 +2,11 @@
 
 ## The Short Version
 
-Be kind to others. Do not insult or put down others. Behave professionally. Remember that harassment and sexist, racist, or exclusionary jokes are not appropriate for NumFOCUS.
+Be kind to others. Do not insult or put down others. Behave professionally. Remember that harassment and sexist, racist, or exclusionary jokes are not appropriate for [PROJECT].
 
 All communication should be appropriate for a professional audience including people of many different backgrounds. Sexual language and imagery is not appropriate.
 
-NumFOCUS is dedicated to providing a harassment-free community for everyone, regardless of gender, sexual orientation, gender identity, and expression, disability, physical appearance, body size, race, or religion. We do not tolerate harassment of community members in any form.
+[PROJECT] is dedicated to providing a harassment-free community for everyone, regardless of gender, sexual orientation, gender identity and expression, disability, physical appearance, body size, race, or religion. We do not tolerate harassment of community members in any form.
 
 Thank you for helping make this a welcoming, friendly community for all.
 
@@ -14,33 +14,33 @@ Thank you for helping make this a welcoming, friendly community for all.
 
 ## The Longer Version
 
-### NumFOCUS Diversity Statement
+### [PROJECT] Diversity Statement
 
-NumFOCUS welcomes and encourages participation in our community by people of all backgrounds and identities. We are committed to promoting and sustaining a culture that values mutual respect, tolerance, and learning, and we work together as a community to help each other live out these values.
+[PROJECT] welcomes and encourages participation in our community by people of all backgrounds and identities. We are committed to promoting and sustaining a culture that values mutual respect, tolerance, and learning, and we work together as a community to help each other live out these values.
 
 We have created this diversity statement because we believe that a diverse community is stronger, more vibrant, and produces better software and better science. A diverse community where people treat each other with respect has more potential contributors, more sources for ideas, and fewer shared assumptions that might hinder development or research.
 
-Although we have phrased the formal diversity statement generically to make it all-inclusive, we recognize that there are specific identities that are impacted by systemic discrimination and marginalization. We welcome all people to participate in the NumFOCUS community regardless of their identity or background.
+Although we have phrased the formal diversity statement generically to make it all-inclusive, we recognize that there are specific identities that are impacted by systemic discrimination and marginalization. We welcome all people to participate in the [PROJECT] community regardless of their identity or background.
 
-### NumFOCUS Code of Conduct: Introduction & Scope
+### [PROJECT] Code of Conduct: Introduction & Scope
 
-This code of conduct should be honored by everyone who participates in the NumFOCUS community. It should be honored in any NumFOCUS-related activities, by anyone claiming affiliation with NumFOCUS, and especially when someone is representing NumFOCUS in any role (including as an event volunteer or speaker).
+This code of conduct should be honored by everyone who participates in the [PROJECT] community. It should be honored in any [PROJECT]-related activities, by anyone claiming affiliation with [PROJECT], and especially when someone is representing [PROJECT] in any role (including as an event volunteer or speaker).
 
-This code of conduct applies to all spaces managed by NumFOCUS, including all public and private mailing lists, issue trackers, wikis, forums, and any other communication channel used by our community. The code of conduct equally applies at NumFOCUS events and governs standards of behavior for attendees, speakers, volunteers, booth staff, and event sponsors.
+This code of conduct applies to all spaces managed by [PROJECT], including all public and private mailing lists, issue trackers, wikis, forums, and any other communication channel used by our community. The code of conduct equally applies at [PROJECT] events and governs standards of behavior for attendees, speakers, volunteers, booth staff, and event sponsors.
 
-This code is not exhaustive or complete. It serves to distill our understanding of a collaborative, inclusive community culture. Please try to follow this code in spirit as much as in letter, to create a friendly and productive environment that enriches the NumFOCUS community.
+This code is not exhaustive or complete. It serves to distill our understanding of a collaborative, inclusive community culture. Please try to follow this code in spirit as much as in letter, to create a friendly and productive environment that enriches the [PROJECT] community.
 
-We require all NumFOCUS sponsored and affiliated projects to adopt a code of conduct for their project that encourages a productive, respectful environment for all open source contributors and community members. The NumFOCUS Code of Conduct follows below.
+The [PROJECT] Code of Conduct follows below.
 
 ### Standards for Behavior
 
-NumFOCUS is a worldwide community. All communication should be appropriate for a professional audience including people of many different backgrounds.
+[PROJECT] is a worldwide community. All communication should be appropriate for a professional audience including people of many different backgrounds.
 
 **Please always be kind and courteous. There's never a need to be mean or rude or disrespectful.** Thank you for helping make this a welcoming, friendly community for all.
 
 We strive to:
 
-**Be empathetic, welcoming, friendly, and patient.** We remember that every NumFOCUS project and program is crafted by human beings who deserve to be treated with kindness and empathy. We work together to resolve conflict and assume good intentions. We may all experience some frustration from time to time, but we do not allow frustration to turn into a personal attack. A community where people feel uncomfortable or threatened is not a productive one.
+**Be empathetic, welcoming, friendly, and patient.** We remember that [PROJECT] is crafted by human beings who deserve to be treated with kindness and empathy. We work together to resolve conflict and assume good intentions. We may all experience some frustration from time to time, but we do not allow frustration to turn into a personal attack. A community where people feel uncomfortable or threatened is not a productive one.
 
 **Be collaborative.** Our work depends on the participation of many people, and in turn others depend on our work. Open source communities depend on effective and friendly collaboration to achieve their goals.
 
@@ -72,59 +72,62 @@ We will not accept harassment or other exclusionary behaviours, such as:
 
 ### Reporting Guidelines
 
-If you believe someone is violating the code of conduct, please report this in a timely manner. Code of conduct violations reduce the value of the community for everyone. The team at NumFOCUS takes reports of misconduct very seriously and is committed to preserving and maintaining the welcoming nature of our community.
+If you believe someone is violating the code of conduct, please report this in a timely manner. Code of conduct violations reduce the value of the community for everyone. The [PROJECT] leadership team takes reports of misconduct very seriously and is committed to preserving and maintaining the welcoming nature of our community.
 
 **All reports will be kept confidential.**
 
 In some cases we may determine that a public statement will need to be made. If that's the case, the identities of all involved parties and reporters will remain confidential unless those individuals instruct us otherwise.
 
-All complaints will be reviewed and investigated and will result in a response that is deemed necessary and appropriate to the circumstances.  The NumFOCUS team commits to maintaining confidentiality with regard to the reporter of an incident.
+All complaints will be reviewed and investigated and will result in a response that is deemed necessary and appropriate to the circumstances.  The [PROJECT] team commits to maintaining confidentiality with regard to the reporter of an incident.
 
-For possibly unintentional breaches of the code of conduct, you may want to respond to the person and point out this code of conduct (either in public or in private, whatever is most appropriate). If you would prefer not to do that, please report the issue to NumFOCUS directly, or ask NumFOCUS Executive Director Leah Silen for advice in confidence (leah@numfocus.org). Complete contact information is below, under "How to Submit a Report."
+For possibly unintentional breaches of the code of conduct, you may want to respond to the person and point out this code of conduct (either in public or in private, whatever is most appropriate). If you would prefer not to do that, please report the issue to [PROJECT] directly, or ask [PROJECT CoC Point Person(s)] for advice in confidence ([PROJECT CoC Point Person(s) Email address or other means of contact]). Complete contact information is below, under "How to Submit a Report."
 
-Take care of each other. Alert NumFOCUS if you notice a dangerous situation, someone in distress, or violations of this code of conduct, even if they seem inconsequential.
+Take care of each other. Alert [PROJECT] if you notice a dangerous situation, someone in distress, or violations of this code of conduct, even if they seem inconsequential.
 
 #### How to Submit a Report
 
-**If you feel your safety is in jeopardy or the situation is an emergency, we urge you to contact local law enforcement before making a report to NumFOCUS.** (In the U.S., dial 911.)
+**If you feel your safety is in jeopardy or the situation is an emergency, we urge you to contact local law enforcement before making a report to [PROJECT].** (In the U.S., dial 911.)
 
-NumFOCUS is committed to promptly addressing any reported issues. If you have experienced or witnessed behavior that violates the NumFOCUS Code of Conduct, please complete the form below to make a report.
+[PROJECT] is committed to promptly addressing any reported issues. If you have experienced or witnessed behavior that violates the [PROJECT] Code of Conduct, please complete the form below to make a report.
 
 **REPORTING FORM:** [*https://numfocus.typeform.com/to/ynjGdT*](https://numfocus.typeform.com/to/ynjGdT)
 
-Reports are sent to the NumFOCUS Code of Conduct Enforcement Team (see below).
+Reports are sent to the [PROJECT] Code of Conduct Enforcement Team (see below).
 
 You can view the Privacy Policy and Terms of Service for TypeForm at [*https://terms.typeform.com/to/fJAmVc*](https://terms.typeform.com/to/fJAmVc). The NumFOCUS Privacy Policy is at [*https://www.numfocus.org/privacy-policy*](https://www.numfocus.org/privacy-policy)
+[MAY NEED TO INSERT LANGUAGE HERE RE: THE PROJECT'S PRIVACY POLICY]
 
 #### Person(s) Responsible for Resolving Complaints
 
-All reports of breaches of the code of conduct will be investigated and handled by the **NumFOCUS Code of Conduct Enforcement Team**.
+All reports of breaches of the code of conduct will be investigated and handled by the **[PROJECT] Code of Conduct Enforcement Team**.
 
-The current NumFOCUS Code of Conduct Enforcement Team consists of:
+The current [PROJECT] Code of Conduct Enforcement Team consists of:
 
--   Leah Silen, Executive Director
+-   [NAME 1]
 
-    -   [*leah@numfocus.org*](mailto:leah@numfocus.org)
+    -   [*EMAIL*](mailto:EMAIL)
 
-    -   +1 (512) 831-2870 or +1 (972) 896-3688
+    -   +1 PHONE NUMBER (OPTIONAL)  
 
--   Andy Terrel, President
+-   [NAME 2]
 
-    -   [*andy@numfocus.org*](mailto:andy@numfocus.org)
+    -   [*EMAIL*](mailto:EMAIL)
 
--   Gina Helfrich, Communications Director and Program Manager for Diversity & Inclusion
+    -   +1 PHONE NUMBER (OPTIONAL)  
+    
+-   [NAME 3]
 
-    -   [*gina@numfocus.org*](mailto:gina@numfocus.org)
+    -   [*EMAIL*](mailto:EMAIL)
 
-You can reach the entire Code of Conduct Enforcement Team by emailing [***conduct@numfocus.org***](mailto:conduct@numfocus.org).
+    -   +1 PHONE NUMBER (OPTIONAL)  
 
-If an incident takes place at an event or meetup or within the community channels of a NumFOCUS project, the NumFOCUS Code of Conduct Enforcement Team will reach out to the relevant organizers/community managers/project leaders as necessary to follow up on the incident.
+You can reach the entire Code of Conduct Enforcement Team by emailing [***EMAIL ADDRESS***](mailto:EMAIL ADDRESS).
 
 #### Conflicts of Interest
 
-In the event of any conflict of interest, the team member will immediately notify the Board and recuse themselves if necessary.
+In the event of any conflict of interest, the team member will immediately notify the [PROJECT] Code of Conduct Enforcement Team and recuse themselves if necessary.
 
-If you are concerned about making a report that will be read by any of the above individuals, please reach out to one of the members of the [*NumFOCUS Board*](https://www.numfocus.org/people#people-directors).
+If you are concerned about making a report that will be read by any of the above individuals, please reach out to [Leah Silen](mailto:leah@numfocus.org), Executive Director of NumFOCUS (https://numfocus.org/code-of-conduct#persons-responsible). [MAY WANT TO INSERT LANGUAGE HERE DESCRIBING THE RELATIONSHIP BETWEEN THE PROJECT AND NUMFOCUS. E.G. "[PROJECT] IS AN AFFILIATED PROJECT OF NUMFOCUS."]
 
 #### What to Include in a Report
 
@@ -139,9 +142,9 @@ Our ability to address any code of conduct breaches in a timely and effective ma
 - Names and contact info, if possible, of **anyone else who witnessed** or was involved in this incident. (Did anyone else observe the incident?)
 - **Any other relevant information** you believe we should have
 
-Event staff/meetup organizers will attempt to gather and write down the above information from anyone making a verbal report in-person at an event. Recording the details in writing is exceedingly important in order for us to effectively respond to reports. If event staff/meetup organizers write down a report taken verbally, then the person making the report will be asked to review the written report for accuracy.
+At [PROJECT] Events: Event staff will attempt to gather and write down the above information from anyone making a verbal report in-person at an event. Recording the details in writing is exceedingly important in order for us to effectively respond to reports. If event staff write down a report taken verbally, then the person making the report will be asked to review the written report for accuracy.
 
-**If urgent action is needed regarding an incident at an in-person event, we strongly encourage you to reach out to the local event staff/meetup organizers for immediate assistance.**
+**If urgent action is needed regarding an incident at an in-person event, we strongly encourage you to reach out to the local event staff for immediate assistance.**
 
 ### Enforcement: What Happens After a Report is Filed?
 
@@ -149,44 +152,44 @@ What happens after a report is filed?
 
 #### Acknowledgment and Responding to Immediate Needs
 
-NumFOCUS and/or our event staff will attempt to ensure your safety and help with any immediate needs, particularly at an in-person event.  NumFOCUS will make every effort to **acknowledge receipt within 24 hours** (and we'll aim for much more quickly than that).
+[PROJECT] and/or our event staff will attempt to ensure your safety and help with any immediate needs, particularly at an in-person event.  [PROJECT] will make every effort to **acknowledge receipt within 24 hours** (and we'll aim for much more quickly than that).  
+
+[PROJECT SHOULD REVIEW THE RESPONSE SCHEDULE LISTED ABOVE AND BELOW, AND DETERMINE WHETHER IT IS REALISTIC FOR THE PROJECT.]
 
 #### Reviewing the Report
 
-NumFOCUS will make all efforts to **review the incident within three days** and determine:
+[PROJECT] will make all efforts to **review the incident within three days** and determine:
 
 - Whether this is an ongoing situation, or if there is a threat to anyone's physical safety
 - What happened
 - Whether this event constitutes a code of conduct violation
 - Who the bad actor was, if any
 
-If the incident took place at an event or meetup or within the community channels of a NumFOCUS project, the NumFOCUS Code of Conduct Enforcement Team will reach out to the relevant organizers/community managers/project leaders as necessary to follow up on the incident.
-
 #### Contacting the Person Reported
 
-After NumFOCUS has had time to review and discuss the report, someone will attempt to contact the person who is the subject of the report to inform them of what has been reported about them. We will then ask that person for their account of what happened.
+After [PROJECT] has had time to review and discuss the report, someone will attempt to contact the person who is the subject of the report to inform them of what has been reported about them. We will then ask that person for their account of what happened.
 
 #### Response and Potential Consequences
 
-Once NumFOCUS has completed our investigation of the report, we will make a decision as to how to respond. The person making a report will not normally be consulted as to the proposed resolution of the issue, except insofar as we need to understand how to help them feel safe.
+Once [PROJECT] has completed our investigation of the report, we will make a decision as to how to respond. The person making a report will not normally be consulted as to the proposed resolution of the issue, except insofar as we need to understand how to help them feel safe.
 
-Potential consequences for violating the NumFOCUS code of conduct include:
+Potential consequences for violating the [PROJECT] code of conduct include:
 
 - Nothing (if we determine that no violation occurred)
-- Private feedback or reprimand from NumFOCUS to the individual(s) involved
+- Private feedback or reprimand from [PROJECT] to the individual(s) involved
 - Warning the person to cease their behavior and that any further reports will result in sanctions
 - A public announcement that an incident occurred
 - Mediation (only if both reporter and reportee agree)
 - An imposed vacation (e.g. asking someone to "take a week off" from a mailing list)
-- A permanent or temporary ban from some or all NumFOCUS spaces (mailing lists, GitHub repos, in-person events, etc.)
+- A permanent or temporary ban from some or all [PROJECT] spaces (mailing lists, GitHub repos, in-person events, etc.)
 - Assistance to the complainant with a report to other bodies, for example, institutional offices or appropriate law enforcement agencies
-- Removing a person from NumFOCUS membership or other formal affiliation
+- Removing a person from [PROJECT] membership or other formal affiliation
 - Publishing an account of the harassment and calling for the resignation of the alleged harasser from their responsibilities (usually pursued by people without formal authority: may be called for if the person is the event leader, or refuses to stand aside from the conflict of interest, or similar)
-- Any other response that NumFOCUS deems necessary and appropriate to the situation
+- Any other response that [PROJECT] deems necessary and appropriate to the situation
 
-At NumFOCUS events, if a participant engages in behavior that violates this code of conduct, the conference organizers and staff may take any action they deem appropriate.
+At [PROJECT] events, if a participant engages in behavior that violates this code of conduct, the conference organizers and staff may take any action they deem appropriate.
 
-Potential consequences for violating the NumFOCUS Code of Conduct at an in-person event include:
+Potential consequences for violating the [PROJECT] Code of Conduct at an in-person event include:
 
 - Warning the person to cease their behavior and that any further reports will result in sanctions
 - Requiring that the person avoid any interaction with, and physical proximity to, the person they are harassing for the remainder of the event
@@ -194,35 +197,35 @@ Potential consequences for violating the NumFOCUS Code of Conduct at an in-perso
 - Not publishing the video or slides of a talk that violated the policy
 - Not allowing a speaker who violated the policy to give (further) talks at the event now or in the future
 - Immediately ending any event volunteer responsibilities and privileges the reported person holds
-- Requiring that the person not volunteer for future events NumFOCUS runs (either indefinitely or for a certain time period)
+- Requiring that the person not volunteer for future events [PROJECT] runs (either indefinitely or for a certain time period)
 - Expelling the person from the event without a refund
 - Requiring that the person immediately leave the event and not return
 - Banning the person from future events (either indefinitely or for a certain time period)
-- Any other response that NumFOCUS deems necessary and appropriate to the situation
+- Any other response that [PROJECT] deems necessary and appropriate to the situation
 
-No one espousing views or values contrary to the standards of our code of conduct will be permitted to hold any position representing NumFOCUS, including volunteer positions. NumFOCUS has the right and responsibility to remove, edit, or reject comments, commits, code, wiki edits, issues, and other contributions that are not aligned with this code of conduct.
+No one espousing views or values contrary to the standards of our code of conduct will be permitted to hold any position representing [PROJECT], including volunteer positions. [PROJECT] has the right and responsibility to remove, edit, or reject comments, commits, code, wiki edits, issues, and other contributions that are not aligned with this code of conduct.
 
 We aim to **respond within one week** to the original reporter with either a resolution or an explanation of why the situation is not yet resolved.
 
-We will write to the person who is the subject of the report to let them know what actions will be taken as a result of the report, if any.
+We will contact the person who is the subject of the report to let them know what actions will be taken as a result of the report, if any.
 
-Our policy is to make sure that everyone aware of the initial incident is also made aware that official action has been taken, while still respecting the privacy of individuals. NumFOCUS may choose to make a public report of the incident, while maintaining the anonymity of those involved.
+Our policy is to make sure that everyone aware of the initial incident is also made aware that official action has been taken, while still respecting the privacy of individuals. [PROJECT] may choose to make a public report of the incident, while maintaining the anonymity of those involved.
 
 #### Appealing a Decision
 
-To appeal a decision of NumFOCUS, contact Leah Silen via email at
-[*leah@numfocus.org*](mailto:leah@numfocus.org) with your appeal and
-the Board will review the case.
+To appeal a decision of [PROJECT], contact [PROJECT CoC Point Person] via email at
+[*EMAIL ADDRESS*](mailto:EMAIL ADDRESS) with your appeal and
+the [PROJECT CoC TEAM/LEADERSHIP TEAM] will review the case.
 
 ### Timeline Summary:
 
 #### Confirming Receipt
 
-NumFOCUS will make every effort to acknowledge receipt of a report **within 24 hours** (and we'll aim for much more quickly than that).
+[PROJECT] will make every effort to acknowledge receipt of a report **within 24 hours** (and we'll aim for much more quickly than that).
 
 #### Reviewing the Report
 
-NumFOCUS will make all efforts to review the incident **within three days**.
+[PROJECT] will make all efforts to review the incident **within three days**.
 
 #### Consequences & Resolution
 
@@ -232,4 +235,4 @@ We aim to respond **within one week** to the original reporter with either a res
 
 This code of conduct has been adapted from numerous sources, including the [*Geek Feminism wiki, created by the Ada Initiative and other volunteers, which is under a Creative Commons Zero license*](http://geekfeminism.wikia.com/wiki/Conference_anti-harassment/Policy), the [*Contributor Covenant version 1.2.0*](http://contributor-covenant.org/version/1/2/0/), the [*Bokeh Code of Conduct*](https://github.com/bokeh/bokeh/blob/master/CODE_OF_CONDUCT.md), the [*SciPy Code of Conduct*](https://github.com/jupyter/governance/blob/master/conduct/enforcement.md), the [*Carpentries Code of Conduct*](https://docs.carpentries.org/topic_folders/policies/code-of-conduct.html#enforcement-manual), and the [*NIPS Code of Conduct*](https://nips.cc/public/CodeOfConduct).
 
-**NumFOCUS Code of Conduct is licensed under the [Creative Commons Attribution 3.0 Unported License](https://creativecommons.org/licenses/by/3.0/).**
+**[PROJECT] Code of Conduct is licensed under the [Creative Commons Attribution 3.0 Unported License](https://creativecommons.org/licenses/by/3.0/).**

--- a/manual/numfocus-coc.md
+++ b/manual/numfocus-coc.md
@@ -1,5 +1,30 @@
 # [PROJECT] Code of Conduct
 
+**Table of Contents**
+
+- [The Short Version](#the-short-version)
+- [The Longer Version](#the-longer-version)
+  - [[PROJECT] Diversity Statement](#project-diversity-statement)
+  - [[PROJECT] Code of Conduct: Introduction & Scope](#project-code-of-conduct-introduction--scope)
+  - [Standards for Behavior](#standards-for-behavior)
+    - [Unacceptable Behavior](#unacceptable-behavior)
+  - [Reporting Guidelines](#reporting-guidelines)
+    - [How to Submit a Report](#how-to-submit-a-report)
+    - [Person(s) Responsible for Resolving Complaints](#persons-responsible-for-resolving-complaints)
+    - [Conflicts of Interest](#conflicts-of-interest)
+    - [What to Include in a Report](#what-to-include-in-a-report)
+  - [Enforcement: What Happens After a Report is Filed?](#enforcement-what-happens-after-a-report-is-filed)
+    - [Acknowledgment and Responding to Immediate Needs](#acknowledgment-and-responding-to-immediate-needs)
+    - [Reviewing the Report](#reviewing-the-report)
+    - [Contacting the Person Reported](#contacting-the-person-reported)
+    - [Response and Potential Consequences](#response-and-potential-consequences)
+    - [Appealing a Decision](#appealing-a-decision)
+  - [Timeline Summary:](#timeline-summary)
+    - [Confirming Receipt](#confirming-receipt)
+    - [Reviewing the Report](#reviewing-the-report-1)
+    - [Consequences & Resolution](#consequences--resolution)
+- [License](#license)
+
 ## The Short Version
 
 Be kind to others. Do not insult or put down others. Behave professionally. Remember that harassment and sexist, racist, or exclusionary jokes are not appropriate for [PROJECT].


### PR DESCRIPTION
For including in their own projects, I imagine projects would find a Markdown version of our CoC handy.  I've translated ours from the Google Doc, and removed the section about "what if this happens at a NumFOCUS event", since that is not relevant for projects.